### PR TITLE
Fix issue #2, service should should fail requests to bad addresses

### DIFF
--- a/GetContentFromURL/content-as-a-service/lib/contentService.js
+++ b/GetContentFromURL/content-as-a-service/lib/contentService.js
@@ -27,15 +27,20 @@ ContentService.prototype.startService = function() {
 
 ContentService.prototype.fetchData = function(url, callback) {
   request({
+    method: 'GET',
     uri: url,
     timeout: 150000,
   }, function(error, response, body) {
     if (error) {
-      callback(error.code, null);
+      response = {}
+      response.statusCode = 500;
+      response.statusMessage = error.errno;
+
+      callback(error.code, response, null);
     } else {
       //html = body.replace(/<script(.*?)<\/script>/g, ' ');
       var text = hget(body, {});
-      callback(null, text);
+      callback(null, response, text);
     }
   });
 

--- a/GetContentFromURL/content-as-a-service/routes/index.js
+++ b/GetContentFromURL/content-as-a-service/routes/index.js
@@ -17,7 +17,9 @@ module.exports = function(app, useCors) {
     var url = utils.url(req.param('url'));
 
     console.log('Get page content for url: %s', url);
-    contentService.fetchData(url, function (err, data) {
+    contentService.fetchData(url, function (err, response, data) {
+      res.statusCode = response.statusCode;
+      res.statusMessage = response.statusMessage;
       res.write(err || data);
       res.end();
     })


### PR DESCRIPTION
Fix issue #2 : should return the correct StatusCode / StatusMessage:

* SUCCESS
```
http http://localhost:6000/\?url\=www.botdream.com
HTTP/1.1 200 OK
Connection: keep-alive
Date: Tue, 20 Dec 2016 17:56:47 GMT
Transfer-Encoding: chunked
X-Powered-By: Express
```

* ERROR
```
http http://localhost:6000/\?url\=moo
HTTP/1.1 500 ENOTFOUND
Connection: keep-alive
Date: Tue, 20 Dec 2016 17:57:00 GMT
Transfer-Encoding: chunked
X-Powered-By: Express

ENOTFOUND
```