### PR TITLE
Fix issue #4: retrieve the page title and return it for the Title field

### DIFF
--- a/CouchDBLucene/database_init.sh
+++ b/CouchDBLucene/database_init.sh
@@ -10,7 +10,8 @@ curl -H 'Content-Type: application/json' \
   -X POST http://localhost:5984/searchengine \
   -d '{"_id": "_design/search", 
         "fulltext": {
-          "by_content": { "index": "function(doc) { var ret=new Document(); ret.add(doc.content); return ret }" }
+          "by_content": { "index": "function(doc) { var ret=new Document(); ret.add(doc.content); return ret }" },
+          "by_title": { "index": "function(doc) { var ret=new Document(); ret.add(doc.title); return ret }" }
         }
       }'
 

--- a/GetContentFromURL/content-as-a-service/lib/contentService.js
+++ b/GetContentFromURL/content-as-a-service/lib/contentService.js
@@ -35,15 +35,21 @@ ContentService.prototype.fetchData = function(url, callback) {
       response = {}
       response.statusCode = 500;
       response.statusMessage = error.errno;
-
-      callback(error.code, response, null);
+      callback(error.code, response, {
+        "url": url,
+        "error": error.errno
+      });
     } else {
       //html = body.replace(/<script(.*?)<\/script>/g, ' ');
+      var title = hget(body, {"root": "title"});
       var text = hget(body, {});
-      callback(null, response, text);
+      callback(null, response, {
+        "url": url,
+        "title": title,
+        "content": text
+      });
     }
   });
-
 }
 
 module.exports = ContentService;

--- a/GetContentFromURL/content-as-a-service/lib/contentService.js
+++ b/GetContentFromURL/content-as-a-service/lib/contentService.js
@@ -27,15 +27,20 @@ ContentService.prototype.startService = function() {
 
 ContentService.prototype.fetchData = function(url, callback) {
   request({
+    method: 'GET',
     uri: url,
     timeout: 150000,
   }, function(error, response, body) {
     if (error) {
-      callback(error.code, null);
+      response = {}
+      response.statusCode = 500;
+      response.statusMessage = error.errno;
+
+      callback(error.code, response, null);
     } else {
       //html = body.replace(/<script(.*?)<\/script>/g, ' ');
       var text = hget(body, {});
-      callback(null, text);
+      callback(null, response, text);
     }
   });
 

--- a/GetContentFromURL/content-as-a-service/routes/index.js
+++ b/GetContentFromURL/content-as-a-service/routes/index.js
@@ -20,7 +20,8 @@ module.exports = function(app, useCors) {
     contentService.fetchData(url, function (err, response, data) {
       res.statusCode = response.statusCode;
       res.statusMessage = response.statusMessage;
-      res.write(err || data);
+      res.writeHead(200, {"Content-Type": "application/json"});
+      res.write(JSON.stringify(data));
       res.end();
     })
   });

--- a/GetContentFromURL/content-as-a-service/routes/index.js
+++ b/GetContentFromURL/content-as-a-service/routes/index.js
@@ -17,7 +17,9 @@ module.exports = function(app, useCors) {
     var url = utils.url(req.param('url'));
 
     console.log('Get page content for url: %s', url);
-    contentService.fetchData(url, function (err, data) {
+    contentService.fetchData(url, function (err, response, data) {
+      res.statusCode = response.statusCode;
+      res.statusMessage = response.statusMessage;
       res.write(err || data);
       res.end();
     })

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ CTRL+C in the original terminal
 
 // clean services data (reset containers)
 docker-compose rm
+
+// when changing source code you should rebuild docker images, use this generic command to build all and ignore cache (will take some time, forces to rebuild all images from scratch)
+docker-compose build --no-cache
 ```
 
 TODO:
@@ -184,5 +187,12 @@ This takes the given url, passes it through GetContentFromURL, then pushes it in
 curl http://localhost:6001/www.botdream.com
 
 then when its done:
+
+```
 curl -X GET --silent http://localhost:5984/_fti/local/searchengine/_design/search/by_content?q=botdream&include_docs=true | jq .
+```
+
+NOTE: service engine is now indexing by title:
+```
+curl -X GET --silent http://localhost:5984/_fti/local/searchengine/_design/search/by_title\?q\=botdream\&include_docs\=true | jq .
 ```

--- a/SaveUrlIntoDB/src/app.js
+++ b/SaveUrlIntoDB/src/app.js
@@ -39,7 +39,11 @@ function webhandler(request, reply) {
     var url = request.params.url;
     getContent(url)
         .then(function(content) {
-            var doc = contentDocumentFactory(url, content, "");
+            var data = JSON.parse(content)
+            if (data.hasOwnProperty("error") && data.error != "") {
+                throw new Error(data.error);
+            }
+            var doc = contentDocumentFactory(url, data.content, data.title);
             return CDB.put(doc);
         })
         .then(function() {


### PR DESCRIPTION
* GetContentFromURL: should retrieve the page title
* SaveUrlIntoDB: should save the page title
* CouchDBLucene: _design/search view should be able to query by title
NOTE: fixed unknown issue, SaveUrlIntoDB was saving the content even if GetContentFromURL returned ERROR. (PR will not allow content to be saved if there is an error)

```
curl http://localhost:6001/www.sevencode.pt
> success

curl -X GET --silent http://localhost:5984/_fti/local/searchengine/_design/search/by_title\?q\=consultancy\&include_docs\=true | jq .

{
  "limit": 25,
  "etag": "fa164386d8",
  "fetch_duration": 45,
  "q": "default:consultancy",
  "search_duration": 0,
  "total_rows": 1,
  "skip": 0,
  "rows": [
    {
      "id": "www-sevencode-pt-sevencode-consultancy-services-software-development-webdevelopment/2016-12-21T17:37:10.674Z",
      "doc": {
        "content": "Coming soon, stay tuned!",
        "_rev": "1-f6e681971a21b750d590248506ac788f",
        "title": "SevenCode: consultancy services, software development, webdevelopment.",
        "_id": "www-sevencode-pt-sevencode-consultancy-services-software-development-webdevelopment/2016-12-21T17:37:10.674Z"
      },
      "score": 0.8447861671447754
    }
  ]
}
```